### PR TITLE
chore: Removed environment url

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,9 +9,10 @@ on:
             tag:
                 required: true
                 type: string
-            environment_url:
+            register_deployment:
                 required: false
-                type: string
+                type: boolean
+                default: false
         secrets:
             GOOGLE_WORKLOAD_IDENTITY_PROVIDER:
                 required: true
@@ -44,7 +45,7 @@ jobs:
         steps:
         -   uses: actions/checkout@v3
         -   uses: bobheadxi/deployments@v1
-            if: "${{ inputs.environment_url != '' }}"
+            if: "${{ inputs.register_deployment }}"
             id: deployment
             with:
                 step: start
@@ -67,11 +68,10 @@ jobs:
                 CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
                 CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
         -   uses: bobheadxi/deployments@v1
-            if: "${{ inputs.environment_url != '' }}"
+            if: "${{ inputs.register_deployment }}"
             with:
                 step: finish
                 token: ${{ secrets.GITHUB_TOKEN }}
                 status: ${{ job.status }}
                 deployment_id: ${{ steps.deployment.outputs.deployment_id }}
                 env: ${{ inputs.environment }}
-                env_url: "${{ inputs.environment_url }}"

--- a/.github/workflows/deploy_release.yaml
+++ b/.github/workflows/deploy_release.yaml
@@ -16,12 +16,9 @@ jobs:
             run: echo "var=${{ env.GITHUB_REF_SLUG_URL }}" >> $GITHUB_OUTPUT
         -   id: tag
             run: echo "var=${{ env.GITHUB_SHA_SHORT }}" >> $GITHUB_OUTPUT
-        -   id: project_url_slug
-            run: echo "var=${{ secrets.GOOGLE_PROJECT_ID }}" >> $GITHUB_OUTPUT
         outputs:
             environment: ${{ steps.environment.outputs.var }}
             tag: ${{ steps.tag.outputs.var }}
-            project_url_slug: ${{ steps.project_url_slug.outputs.var }}
 
     build:
         needs: [ deploy_slug ]
@@ -31,7 +28,7 @@ jobs:
             environment: ${{ needs.deploy_slug.outputs.environment }}
             tag: ${{ needs.deploy_slug.outputs.tag }}
 
-    deploy_prerelease:
+    deploy:
         needs: [ deploy_slug, build ]
         if: "${{ needs.deploy_slug.outputs.environment != 'main' }}"
         uses: ./.github/workflows/deploy.yaml
@@ -40,17 +37,7 @@ jobs:
         with:
             environment: ${{ needs.deploy_slug.outputs.environment }}
             tag: ${{ needs.deploy_slug.outputs.tag }}
-            environment_url: "https://${{ needs.deploy_slug.outputs.environment }}.${{ needs.deploy_slug.outputs.project_url_slug }}.pages.dev"
-    deploy_production:
-        needs: [ deploy_slug, build ]
-        if: "${{ needs.deploy_slug.outputs.environment == 'main' }}"
-        uses: ./.github/workflows/deploy.yaml
-        secrets: inherit
-        concurrency: ${{ needs.deploy_slug.outputs.environment }}
-        with:
-            environment: ${{ needs.deploy_slug.outputs.environment }}
-            tag: ${{ needs.deploy_slug.outputs.tag }}
-            environment_url: "https://${{ needs.deploy_slug.outputs.project_url_slug }}.pages.dev"
+            register_deployment: true
 
     delete_containers:
         needs: [ deploy_slug, build ]


### PR DESCRIPTION
As long as we can not set environment variables using `gh` cli the google_project_id is stored in a secret. The url is based on the id and can not be shown / published.